### PR TITLE
fix bug: MARCXML 655 subfield 2 missing

### DIFF
--- a/backend/model/nyu_custom_model_marc21.rb
+++ b/backend/model/nyu_custom_model_marc21.rb
@@ -234,16 +234,19 @@ class MARCModel < ASpaceExport::ExportModel
         sfs << [tag, t['term']]
       end
 
-      if ind2 == '7'
+      # N.B. ind2 is an array at this point.
+      if ind2[0] == '7'
         sfs << ['2', subject['source']]
       end
+
       # adding this code snippet because I'm making ind2 an array
       # for code 630 if the title begins with an article
       if (ind2.is_a?(Array) && code == '630')
-        ind1,ind2 = ind2
+        ind1, ind2 = ind2
       else
         ind2 = ind2[0]
       end
+
       df!(code, ind1, ind2).with_sfs(*sfs)
     end
   end


### PR DESCRIPTION
Resolved issue where the MARCXML exporter was not exporting
datafield 655, subfield 2 correctly.

The following example is from Weatherly Stephan:

Example: Daniel Rubin Papers (https://archivesspace-dev.library.nyu.edu/resources/1212 or Tamiment TAM 657)
Exports with:
```
    <datafield ind1=" " ind2="7" tag="655">
      <subfield code="a">Audiocassettes.</subfield>
    </datafield>
    <datafield ind1=" " ind2="7" tag="655">
      <subfield code="a">Buttons (information artifacts)</subfield>
    </datafield>
```
But should have:
```
    <datafield ind1=" " ind2="7" tag="655">
      <subfield code="a">Audiocassettes.</subfield>
      <subfield code="2">aat</subfield>
    </datafield>
    <datafield ind1=" " ind2="7" tag="655">
      <subfield code="a">Buttons (information artifacts)</subfield>
      <subfield code="2">aat</subfield>
    </datafield>
```
Bug and Fix Description:
------------------------
The NYU MARCXML exporter differs from the stock ASpace MARCXML
exporter in various ways. This bug was caused by the conversion of the
ind2 variable from a scalar to an array.

  `code, *ind2 =  case term['term_type']`

This causes a bug in the following line:
  `if ind2 == '7'`

ind2 is an array, and therefore will not match the scalar value '7',
so subfield 2 is never added.

The errorneous line was changed to:
  `if ind2[0] == '7'`

Local testing shows that the MARCXML exports with datafield 655 now
contain subfield 2 as desired.