### PR TITLE
Update nyu_custom_model_marc21.rb

### DIFF
--- a/backend/model/nyu_custom_model_marc21.rb
+++ b/backend/model/nyu_custom_model_marc21.rb
@@ -345,6 +345,11 @@ class MARCModel < ASpaceExport::ExportModel
               end
         sfs << [tag, t['term']]
       end
+      
+      # code borrowed from Yale to export subject authority id
+      unless subject['authority_id'].nil?
+        sfs << ['0', subject['authority_id']]
+      end
 
       # N.B. ind2 is an array at this point.
       if ind2[0] == '7'


### PR DESCRIPTION
Added code borrowed from Yale to export subject authority id as $0