### PR TITLE
Update nyu_custom_model_marc21.rb

### DIFF
--- a/backend/model/nyu_custom_model_marc21.rb
+++ b/backend/model/nyu_custom_model_marc21.rb
@@ -346,6 +346,12 @@ class MARCModel < ASpaceExport::ExportModel
         sfs << [tag, t['term']]
       end
 
+      # code borrowed from Yale to export subject authority id
+      unless subject['authority_id'].nil?
+        sfs << ['0', subject['authority_id']]
+      end
+
+      
       # N.B. ind2 is an array at this point.
       if ind2[0] == '7'
         sfs << ['2', subject['source']]


### PR DESCRIPTION
Adding code borrowed from Yale to include subject authority id in export